### PR TITLE
Introduce Chain.HandlerC

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -43,8 +43,14 @@ func (c Chain) Handler(xh HandlerC) http.Handler {
 // HandlerCtx wraps the provided final handler with all the middleware appended to
 // the chain and return a new standard http.Handler instance.
 func (c Chain) HandlerCtx(ctx context.Context, xh HandlerC) http.Handler {
+	return New(ctx, c.HandlerC(xh))
+}
+
+// HandlerC wraps the provided final handler with all the middleware appended to
+// the chain and returns a HandlerC instance.
+func (c Chain) HandlerC(xh HandlerC) HandlerC {
 	for i := len(c) - 1; i >= 0; i-- {
 		xh = c[i](xh)
 	}
-	return New(ctx, xh)
+	return xh
 }


### PR DESCRIPTION
It's quite useful to boil the chain down to one HandlerC in my opinion.
For example you could use it to insert a Chain into a Chain. I use it to better wrap an HandlerC into another mux.

A full example how to wrap a `xhandler` into `goji`:
```
func handle(ctx context.Context, handlerc xhandler.HandlerC) web.HandlerFunc {
	return func(c web.C, w http.ResponseWriter, r *http.Request) {
		newctx := context.WithValue(ctx, "urlparams", c.URLParams)
		handlerc.ServeHTTPC(newctx, w, r)
	}
}
c := xhandler.Chain{}
...
mux.Get("/:name", handle(mainContext, c.HandlerC(IndexHandler)))
```