### PR TITLE
Import the actual context package, not just the whole directory

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -3,7 +3,7 @@ package xhandler
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 // Chain is an helper to chain middleware handlers together for an easier

--- a/chain_example_test.go
+++ b/chain_example_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/rs/cors"
 	"github.com/rs/xhandler"
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 func ExampleChain() {

--- a/chain_test.go
+++ b/chain_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 func TestAppendHandlerC(t *testing.T) {

--- a/middleware.go
+++ b/middleware.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 // CloseHandler returns a Handler cancelling the context when the client

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 func TestTimeoutHandler(t *testing.T) {

--- a/xhandler.go
+++ b/xhandler.go
@@ -14,7 +14,7 @@ package xhandler // import "github.com/rs/xhandler"
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 // HandlerC is a net/context aware http.Handler

--- a/xhandler_example_test.go
+++ b/xhandler_example_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/rs/xhandler"
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 type key int

--- a/xhandler_test.go
+++ b/xhandler_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
+	"golang.org/x/net/context/context"
 )
 
 type handler struct{}


### PR DESCRIPTION
This causes issues with go 1.5.2:

export GOPATH=/Users/nick.veenhof/Servers/my-private-project && export GO15VENDOREXPER
IMENT=1 && go build -o build/decisionapi -ldflags "-X main.version=0.1 -d" decision.go
vendor/github.com/rs/xhandler/chain.go:6:2: no buildable Go source files in /Users/nick.veenhof/Servers/my-private-project/src/github.com/my-private-project/vendor/golang.org/x/net/context

When I apply the changes as shown in the PR, it works like a charm
