### PR TITLE
WIP: moving to go1.7 stdlib context

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -1,93 +1,33 @@
 package xhandler
 
-import (
-	"net/http"
-
-	"golang.org/x/net/context"
-)
+import "net/http"
 
 // Chain is an helper to chain middleware handlers together for an easier
 // management.
-type Chain []func(next HandlerC) HandlerC
+type Chain []func(http.Handler) http.Handler
 
-// UseC appends a context-aware handler to the middleware chain.
-func (c *Chain) UseC(f func(next HandlerC) HandlerC) {
-	*c = append(*c, f)
-}
-
-// Use appends a standard http.Handler to the middleware chain without
-// lossing track of the context when inserted between two context aware handlers.
+// Use appends a context-aware handler to the middleware chain.
 //
 // Caveat: the f function will be called on each request so you are better to put
 // any initialization sequence outside of this function.
 func (c *Chain) Use(f func(next http.Handler) http.Handler) {
-	xf := func(next HandlerC) HandlerC {
-		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			n := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				next.ServeHTTPC(ctx, w, r)
-			})
-			f(n).ServeHTTP(w, r)
-		})
-	}
-	*c = append(*c, xf)
+	*c = append(*c, f)
 }
 
 // Handler wraps the provided final handler with all the middleware appended to
 // the chain and return a new standard http.Handler instance.
 // The context.Background() context is injected automatically.
-func (c Chain) Handler(xh HandlerC) http.Handler {
-	ctx := context.Background()
-	return c.HandlerCtx(ctx, xh)
-}
-
-// HandlerFC is an helper to provide a function (HandlerFuncC) to Handler().
-//
-// HandlerFC is equivalent to:
-//  c.Handler(xhandler.HandlerFuncC(xhc))
-func (c Chain) HandlerFC(xhf HandlerFuncC) http.Handler {
-	ctx := context.Background()
-	return c.HandlerCtx(ctx, HandlerFuncC(xhf))
-}
-
-// HandlerH is an helper to provide a standard http handler (http.HandlerFunc)
-// to Handler(). Your final handler won't have access the context though.
-func (c Chain) HandlerH(h http.Handler) http.Handler {
-	ctx := context.Background()
-	return c.HandlerCtx(ctx, HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		h.ServeHTTP(w, r)
-	}))
+func (c Chain) Handler(h http.Handler) http.Handler {
+	for i := len(c) - 1; i >= 0; i-- {
+		h = c[i](h)
+	}
+	return h
 }
 
 // HandlerF is an helper to provide a standard http handler function
-// (http.HandlerFunc) to Handler(). Your final handler won't have access
-// the context though.
+// (http.HandlerFunc) to Handler().
 func (c Chain) HandlerF(hf http.HandlerFunc) http.Handler {
-	ctx := context.Background()
-	return c.HandlerCtx(ctx, HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	return c.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hf(w, r)
 	}))
-}
-
-// HandlerCtx wraps the provided final handler with all the middleware appended to
-// the chain and return a new standard http.Handler instance.
-func (c Chain) HandlerCtx(ctx context.Context, xh HandlerC) http.Handler {
-	return New(ctx, c.HandlerC(xh))
-}
-
-// HandlerC wraps the provided final handler with all the middleware appended to
-// the chain and returns a HandlerC instance.
-func (c Chain) HandlerC(xh HandlerC) HandlerC {
-	for i := len(c) - 1; i >= 0; i-- {
-		xh = c[i](xh)
-	}
-	return xh
-}
-
-// HandlerCF wraps the provided final handler func with all the middleware appended to
-// the chain and returns a HandlerC instance.
-//
-// HandlerCF is equivalent to:
-//  c.HandlerC(xhandler.HandlerFuncC(xhc))
-func (c Chain) HandlerCF(xhc HandlerFuncC) HandlerC {
-	return c.HandlerC(HandlerFuncC(xhc))
 }

--- a/middleware.go
+++ b/middleware.go
@@ -1,20 +1,19 @@
 package xhandler
 
 import (
+	"context"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // CloseHandler returns a Handler cancelling the context when the client
 // connection close unexpectedly.
-func CloseHandler(next HandlerC) HandlerC {
-	return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+// TODO: not sure this is also in the stdlib now
+func CloseHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Cancel the context if the client closes the connection
 		if wcn, ok := w.(http.CloseNotifier); ok {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithCancel(ctx)
+			ctx, cancel := context.WithCancel(r.Context())
 			defer cancel()
 
 			notify := wcn.CloseNotify()
@@ -25,9 +24,11 @@ func CloseHandler(next HandlerC) HandlerC {
 				case <-ctx.Done():
 				}
 			}()
+			// TODO: needed?
+			r = r.WithContext(ctx)
 		}
 
-		next.ServeHTTPC(ctx, w, r)
+		next.ServeHTTP(w, r)
 	})
 }
 
@@ -35,24 +36,25 @@ func CloseHandler(next HandlerC) HandlerC {
 //
 // Child handlers have the responsability to obey the context deadline and to return
 // an appropriate error (or not) response in case of timeout.
-func TimeoutHandler(timeout time.Duration) func(next HandlerC) HandlerC {
-	return func(next HandlerC) HandlerC {
-		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			ctx, _ = context.WithTimeout(ctx, timeout)
-			next.ServeHTTPC(ctx, w, r)
+func TimeoutHandler(timeout time.Duration) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// TODO: not calling cancel?!
+			ctx, _ := context.WithTimeout(r.Context(), timeout)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }
 
 // If is a special handler that will skip insert the condNext handler only if a condition
 // applies at runtime.
-func If(cond func(ctx context.Context, w http.ResponseWriter, r *http.Request) bool, condNext func(next HandlerC) HandlerC) func(next HandlerC) HandlerC {
-	return func(next HandlerC) HandlerC {
-		return HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-			if cond(ctx, w, r) {
-				condNext(next).ServeHTTPC(ctx, w, r)
+func If(cond func(w http.ResponseWriter, r *http.Request) bool, condNext func(next http.Handler) http.Handler) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if cond(w, r) {
+				condNext(next).ServeHTTP(w, r)
 			} else {
-				next.ServeHTTPC(ctx, w, r)
+				next.ServeHTTP(w, r)
 			}
 		})
 	}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,6 +1,7 @@
 package xhandler
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestTimeoutHandler(t *testing.T) {
@@ -65,18 +65,18 @@ func TestCloseHandlerRequestEnds(t *testing.T) {
 }
 
 func TestIf(t *testing.T) {
-	trueHandler := HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	trueHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/true", r.URL.Path)
 	})
-	falseHandler := HandlerFuncC(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	falseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.NotEqual(t, "/true", r.URL.Path)
 	})
 	ctx := context.WithValue(context.Background(), contextKey, "value")
 	xh := If(
-		func(ctx context.Context, w http.ResponseWriter, r *http.Request) bool {
+		func(w http.ResponseWriter, r *http.Request) bool {
 			return r.URL.Path == "/true"
 		},
-		func(next HandlerC) HandlerC {
+		func(nex http.Handler) http.Handler {
 			return trueHandler
 		},
 	)(falseHandler)

--- a/xhandler.go
+++ b/xhandler.go
@@ -12,31 +12,17 @@
 package xhandler // import "github.com/rs/xhandler"
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
-
-// HandlerC is a net/context aware http.Handler
-type HandlerC interface {
-	ServeHTTPC(context.Context, http.ResponseWriter, *http.Request)
-}
-
-// HandlerFuncC type is an adapter to allow the use of ordinary functions
-// as a xhandler.Handler. If f is a function with the appropriate signature,
-// xhandler.HandlerFuncC(f) is a xhandler.Handler object that calls f.
-type HandlerFuncC func(context.Context, http.ResponseWriter, *http.Request)
-
-// ServeHTTPC calls f(ctx, w, r).
-func (f HandlerFuncC) ServeHTTPC(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	f(ctx, w, r)
-}
 
 // New creates a conventional http.Handler injecting the provided root
 // context to sub handlers. This handler is used as a bridge between conventional
 // http.Handler and context aware handlers.
-func New(ctx context.Context, h HandlerC) http.Handler {
+func New(ctx context.Context, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		h.ServeHTTPC(ctx, w, r)
+		//ctx = context.WithContext(ctx)
+		r = r.WithContext(ctx) // TODO: doesnt smell good.. might loose orig ctx?!
+		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
With go1.7 `context` lives in the [stdlib](https://tip.golang.org/pkg/context/) and is also integrated into [(net/http).Request](https://tip.golang.org/pkg/net/http/#Request.Context).

right now, this is just a rough draft  to see what the API could look like.

TODO:
* [ ] keep it backwards compat through conditinal compilation (i.e. `// +build go1.6`)
* [ ] update documentation